### PR TITLE
feat: Make creation of Kubernetes resources togglable

### DIFF
--- a/modules/bucket/README.md
+++ b/modules/bucket/README.md
@@ -31,6 +31,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-gcp-init. Used to determine application name, application project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment   = string<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
+| <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Whether to create a Kubernetes config map containing the bucket name and URL. | `bool` | `true` | no |
 | <a name="input_disable_offsite_backup"></a> [disable\_offsite\_backup](#input\_disable\_offsite\_backup) | Disable offsite backup of the bucket. Offsite backup is only applied to production environments. | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether to allow Terraform to delete the bucket even if it contains objects. | `bool` | `false` | no |
 | <a name="input_generation"></a> [generation](#input\_generation) | The generation (aka serial no.) of the instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |

--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -61,6 +61,7 @@ resource "google_storage_bucket" "main" {
 }
 
 resource "kubernetes_config_map" "main" {
+  count = var.create_kubernetes_resources ? 1 : 0
   metadata {
     name      = local.config_map_name
     namespace = var.init.app.name

--- a/modules/bucket/variables.tf
+++ b/modules/bucket/variables.tf
@@ -90,3 +90,9 @@ variable "lifecycle_rules_override" {
     error_message = "Every lifecycle rule must have an 'action.type', and contain a 'condition', or be 'null'."
   }
 }
+
+variable "create_kubernetes_resources" {
+  description = "Whether to create a Kubernetes config map containing the bucket name and URL."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
The storage module currently requires a Kubernetes cluster to provision a bucket, which shouldn't be a requirement.

* This PR adds the ability to opt out of Kubernetes resource creation.
* Still defaults to provisioning a Kubernetes config map.

---
ℹ️  **This will trigger the Kubernetes config map to be replaced after upgrade (which is fine)**
This is because the Terraform resource address will change (adding an index). The use of a moved-block is not implemented, as we still maintain backwards compatibility with >=0.13.2.

**What to expect:**
The resource `module.x.kubernetes_config_map.main` will be deleted.
The resource `module.x.kubernetes_config_map[0].main` will be created.

The new resource is identical. The replacement should be brief, and will not impact running pods.